### PR TITLE
[fix]: enforce HwQueue preemption capability

### DIFF
--- a/preempt/CMakeLists.txt
+++ b/preempt/CMakeLists.txt
@@ -40,3 +40,7 @@ target_link_libraries(preempt
     PRIVATE sched
     PRIVATE protocol
 )
+
+if(BUILD_TEST)
+    add_subdirectory(test)
+endif()

--- a/preempt/src/xqueue/xqueue.cpp
+++ b/preempt/src/xqueue/xqueue.cpp
@@ -24,6 +24,14 @@ XResult XQueueManager::Add(XQueueHandle *xq_hp, HwQueueHandle hwq_h, int64_t lev
         return kXSchedErrorNotFound;
     }
 
+    if (level > hwq_shptr->GetMaxSupportedLevel()) {
+        XWARN("preempt level %d is not supported by HwQueue 0x" FMT_64X
+              ", max supported level is %d",
+              static_cast<int>(level), hwq_h,
+              hwq_shptr->GetMaxSupportedLevel());
+        return kXSchedErrorNotSupported;
+    }
+
     if (hwq_shptr->GetXQueue() != nullptr) {
         XQueueHandle xq_h = hwq_shptr->GetXQueue()->GetHandle();
         auto it = xqs_.find(xq_h);
@@ -283,6 +291,12 @@ EXPORT_C_FUNC XResult XQueueSetPreemptLevel(XQueueHandle xq, XPreemptLevel level
     }
     if (!xq_shptr->GetFeatures(kQueueFeatureDynamicLevel)) {
         XWARN("XQueue with handle 0x" FMT_64X " does not support dynamic level", xq);
+        return kXSchedErrorNotSupported;
+    }
+    const auto hwq_shptr = xq_shptr->GetHwQueue();
+    if (hwq_shptr == nullptr || level > hwq_shptr->GetMaxSupportedLevel()) {
+        XWARN("preempt level %d is not supported by XQueue 0x" FMT_64X,
+              level, xq);
         return kXSchedErrorNotSupported;
     }
     xq_shptr->SetPreemptLevel(level);

--- a/preempt/test/CMakeLists.txt
+++ b/preempt/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(preempt_level_capability_test
+    preempt_level_capability_test.cpp
+)
+target_compile_options(preempt_level_capability_test PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+)
+target_link_libraries(preempt_level_capability_test PRIVATE
+    preempt
+    utils
+)
+add_test(NAME preempt_level_capability_test
+         COMMAND preempt_level_capability_test)

--- a/preempt/test/preempt_level_capability_test.cpp
+++ b/preempt/test/preempt_level_capability_test.cpp
@@ -1,0 +1,90 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "xsched/preempt/hal/hw_queue.h"
+#include "xsched/xqueue.h"
+
+namespace
+{
+
+using namespace xsched::preempt;
+
+class CapabilityQueue final : public HwQueue
+{
+public:
+    virtual void Launch(std::shared_ptr<HwCommand>) override { }
+    virtual void Synchronize() override { }
+    virtual void Deactivate() override { ++deactivate_count; }
+    virtual void Reactivate(const CommandLog &) override
+    {
+        ++reactivate_count;
+    }
+
+    virtual XDevice GetDevice() override { return 0; }
+    virtual HwQueueHandle GetHandle() override { return kHandle; }
+    virtual bool SupportDynamicLevel() override { return true; }
+    virtual XPreemptLevel GetMaxSupportedLevel() override
+    {
+        return kPreemptLevelDeactivate;
+    }
+
+    static constexpr HwQueueHandle kHandle = 0xc0ffee;
+    int deactivate_count = 0;
+    int reactivate_count = 0;
+};
+
+bool Expect(bool condition, const std::string &message)
+{
+    if (condition) return true;
+    std::cerr << "FAIL: " << message << '\n';
+    return false;
+}
+
+} // namespace
+
+int main()
+{
+    using namespace xsched::preempt;
+
+    auto queue = std::make_shared<CapabilityQueue>();
+    bool ok = Expect(
+        HwQueueManager::Add(CapabilityQueue::kHandle,
+            [queue]() { return queue; })
+            == kXSchedSuccess,
+        "register Level-2 HwQueue");
+
+    XQueueHandle xqueue = 0;
+    ok &= Expect(XQueueCreate(&xqueue, CapabilityQueue::kHandle,
+                     kPreemptLevelInterrupt,
+                     kQueueCreateFlagNone)
+            == kXSchedErrorNotSupported,
+        "reject Level-3 creation on a Level-2 HwQueue");
+    ok &= Expect(XQueueCreate(&xqueue, CapabilityQueue::kHandle,
+                     kPreemptLevelDeactivate,
+                     kQueueCreateFlagNone)
+            == kXSchedSuccess,
+        "create Level-2 XQueue");
+    if (xqueue != 0) {
+        ok &= Expect(XQueueSetPreemptLevel(xqueue,
+                         kPreemptLevelInterrupt)
+                == kXSchedErrorNotSupported,
+            "reject dynamic upgrade beyond Level-2");
+        ok &= Expect(XQueueSuspend(xqueue, kQueueSuspendFlagNone) == kXSchedSuccess,
+            "suspend Level-2 XQueue");
+        ok &= Expect(queue->deactivate_count == 1,
+            "suspend must call Deactivate");
+        ok &= Expect(XQueueResume(xqueue, kQueueResumeFlagNone) == kXSchedSuccess,
+            "resume Level-2 XQueue");
+        ok &= Expect(queue->reactivate_count == 1,
+            "resume must call Reactivate");
+        ok &= Expect(XQueueDestroy(xqueue) == kXSchedSuccess,
+            "destroy Level-2 XQueue");
+    }
+    ok &= Expect(HwQueueDestroy(CapabilityQueue::kHandle) == kXSchedSuccess,
+        "destroy Level-2 HwQueue");
+
+    if (!ok) return 1;
+    std::cout << "HwQueue preemption capability tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- enforce `HwQueue::GetMaxSupportedLevel()` when creating an XQueue;
- apply the same capability check to dynamic preemption-level changes;
- add a platform-independent Level-2 fake queue test covering creation, rejection of Level-3, suspend/resume dispatch, and dynamic upgrade rejection.

## Motivation

`GetMaxSupportedLevel()` already expresses each HAL queue's preemption capability, but the core runtime previously treated it as advisory: callers could create or upgrade an XQueue to a level the HAL did not implement. A hardware queue that supports deactivation but not command interruption therefore had no reliable way to reject Level-3.

This change makes the existing HAL contract effective without adding any platform-specific behavior.

## Scope

This PR contains only core preemption capability validation and its unit test. It does not add LoongGPU code, OpenCL wrappers, scheduler policy, benchmarks, or application artifacts.

## Validation

- Ubuntu 24.04: core preemption library and capability test build with `-Wall -Wextra -Werror`;
- test verifies Level-3 rejection on a Level-2 HAL, valid Level-2 suspend/resume, and dynamic upgrade rejection;
- `git diff --check` passes.

Validation run: https://github.com/guohuan78/xsched/actions/runs/30080294997
